### PR TITLE
Fix test script

### DIFF
--- a/bin/test-examples
+++ b/bin/test-examples
@@ -7,8 +7,8 @@ fi
 
 cd ./exercises
 
+err_cnt=0
 for ex in *; do
-    err_cnt=0
     impl="${ex}.el"
     cd $ex
     mv $impl "${impl}.tmp"

--- a/bin/test-examples
+++ b/bin/test-examples
@@ -19,9 +19,4 @@ for ex in *; do
     cd -
 done
 
-if [ $err_cnt -ne 0 ]
-then
-    exit 1
-else
-    exit 0
-fi
+[ $err_cnt -eq 0 ] || exit 1

--- a/bin/test-examples
+++ b/bin/test-examples
@@ -5,18 +5,20 @@ if [[ ! -d "exercises" ]]; then
     exit 1
 fi
 
-cd ./exercises
+tar czf exercises.tgz exercises
+pushd $_
 
 err_cnt=0
 for ex in *; do
-    impl="${ex}.el"
-    cd $ex
-    mv $impl "${impl}.tmp"
-    cp example.el $impl
+    pushd $ex
+    mv example.el "${ex}.el"
     emacs -batch -l ert -l "${ex}-test.el" -f ert-run-tests-batch-and-exit
     let "err_cnt += $?"
-    mv "${impl}.tmp" $impl
-    cd -
+    popd
 done
+
+popd
+tar xzf exercises.tgz
+rm $_
 
 [ $err_cnt -eq 0 ] || exit 1


### PR DESCRIPTION
Previously, `err_cnt` was getting reset for each exercises, so the status code for `bin/test-examples` only reflected the results of the last (alphabetic) exercise.