### PR TITLE
Fix two-fer exercise commentary

### DIFF
--- a/exercises/two-fer/two-fer.el
+++ b/exercises/two-fer/two-fer.el
@@ -1,9 +1,9 @@
-;;; hello-world.el --- Hello World Exercise (exercism)
+;;; two-fer.el --- Two-fer Exercise (exercism)
 
 ;;; Commentary:
 
 ;;; Code:
 
 
-(provide 'hello-world)
-;;; hello-world.el ends here
+(provide 'two-fer)
+;;; two-fer.el ends here


### PR DESCRIPTION
I realized that the `two-fer.el` were using the same code template as `hello-world.el`. I updated it.