### PR TITLE
difference-of-squares: renamed square-of-sums to square-of-sum

### DIFF
--- a/exercises/difference-of-squares/difference-of-squares-test.el
+++ b/exercises/difference-of-squares/difference-of-squares-test.el
@@ -6,33 +6,33 @@
 
 (load-file "difference-of-squares.el")
 
-(ert-deftest square-of-sums-to-5 ()
-  (should (= 225 (square-of-sums 5))))
+(ert-deftest square-of-sum-to-5 ()
+  (should (= 225 (square-of-sum 5))))
 
 (ert-deftest sum-of-squares-to-5 ()
   (should (= 55 (sum-of-squares 5))))
 
-(ert-deftest difference-of-sums-to-5 ()
+(ert-deftest difference-of-squares-to-5 ()
   (should (= 170 (difference 5))))
 
 
-(ert-deftest square-of-sums-to-10 ()
-  (should (= 3025 (square-of-sums 10))))
+(ert-deftest square-of-sum-to-10 ()
+  (should (= 3025 (square-of-sum 10))))
 
 (ert-deftest sum-of-squares-to-10 ()
   (should (= 385 (sum-of-squares 10))))
 
-(ert-deftest difference-of-sums-to-10 ()
+(ert-deftest difference-of-squares-to-10 ()
   (should (= 2640 (difference 10))))
 
 
-(ert-deftest square-of-sums-to-100 ()
-  (should (= 25502500 (square-of-sums 100))))
+(ert-deftest square-of-sum-to-100 ()
+  (should (= 25502500 (square-of-sum 100))))
 
 (ert-deftest sum-of-squares-to-100 ()
   (should (= 338350 (sum-of-squares 100))))
 
-(ert-deftest difference-of-sums-to-100 ()
+(ert-deftest difference-of-squares-to-100 ()
   (should (= 25164150 (difference 100))))
 
 

--- a/exercises/difference-of-squares/example.el
+++ b/exercises/difference-of-squares/example.el
@@ -6,16 +6,16 @@
 (eval-when-compile (require 'cl))
 
 (defun sum-of-squares (n)
-  "Square of sums of N."
+  "Square of sum of N."
   (reduce #'+ (mapcar #'(lambda (i) (expt i 2)) (number-sequence 1 n))))
 
-(defun square-of-sums (n)
+(defun square-of-sum (n)
   "Sum of squares of N."
   (expt (reduce #'+ (number-sequence 1 n)) 2))
 
 (defun difference (n)
   "Difference of squares pertaining to N."
-  (- (square-of-sums n)
+  (- (square-of-sum n)
      (sum-of-squares n)))
 
 (provide 'difference-of-squares)


### PR DESCRIPTION
In exercise "difference-of-squares", renamed `square-of-sums` to `square-of-sum`, and `difference-of-sums` to `difference-of-squares`.