### PR TITLE
Use `string=` instead of `equal` in Two-Fer tests

### DIFF
--- a/exercises/two-fer/two-fer-test.el
+++ b/exercises/two-fer/two-fer-test.el
@@ -8,13 +8,13 @@
 (load-file "two-fer.el")
 
 (ert-deftest no-name-given ()
-  (should (equal (two-fer) "One for you, one for me.")))
+  (should (string= (two-fer) "One for you, one for me.")))
 
 (ert-deftest a-name-given ()
-  (should (equal (two-fer "Alice") "One for Alice, one for me.")))
+  (should (string= (two-fer "Alice") "One for Alice, one for me.")))
 
 (ert-deftest another-name-given ()
-  (should (equal (two-fer "Bob") "One for Bob, one for me.")))
+  (should (string= (two-fer "Bob") "One for Bob, one for me.")))
 
 (provide 'two-fer-test)
 


### PR DESCRIPTION
Set a good example.