### PR TITLE
Word count example implementation improvements

### DIFF
--- a/exercises/word-count/example.el
+++ b/exercises/word-count/example.el
@@ -7,10 +7,11 @@
 
 (defun word-count (sentence)
   (let ((count nil))
-    (dolist (i (split-string (downcase sentence) "[^a-z0-9]" t))
-      (let ((n (assoc i count)))
-        (if n (setcdr n (1+ (cdr n)))
-          (push (cons i 1) count))))
+    (dolist (word (split-string (downcase sentence) "[^a-z0-9]" t))
+      (let ((entry (assoc word count)))
+        (if entry
+            (setcdr entry (1+ (cdr entry)))
+          (push (cons word 1) count))))
     count))
 
 

--- a/exercises/word-count/example.el
+++ b/exercises/word-count/example.el
@@ -8,7 +8,7 @@
 (defun word-count (sentence)
   (let ((count nil))
     (dolist (word (split-string (downcase sentence) "[^a-z0-9]" t))
-      (let ((entry (assoc word count)))
+      (let ((entry (assoc-string word count)))
         (if entry
             (setcdr entry (1+ (cdr entry)))
           (push (cons word 1) count))))


### PR DESCRIPTION
Mostly readability/accessibility, but also note usage of `assoc-string` instead of `assoc` to set a good example.