### PR TITLE
Require `cl-lib` instead of `cl`

### DIFF
--- a/exercises/acronym/acronym.el
+++ b/exercises/acronym/acronym.el
@@ -4,7 +4,7 @@
 
 ;;; Code:
 
-(require 'cl)
+(require 'cl-lib)
 
 
 (provide 'acronym)

--- a/exercises/acronym/example.el
+++ b/exercises/acronym/example.el
@@ -4,7 +4,7 @@
 
 ;;; Code:
 
-(require 'cl)
+(require 'cl-lib)
 
 (defun acronym (input)
   (let ((words (split-string input "\\W+")))

--- a/exercises/allergies/example.el
+++ b/exercises/allergies/example.el
@@ -4,7 +4,7 @@
 
 ;;; Code:
 
-(require 'cl)
+(require 'cl-lib)
 
 (defvar *allergens-scores*
   '(("eggs" 1)

--- a/exercises/allergies/example.el
+++ b/exercises/allergies/example.el
@@ -18,11 +18,11 @@
 
 (defun allergen (allergen-and-score)
   "Return allergen from ALLERGEN-AND-SCORE."
-  (first allergen-and-score))
+  (cl-first allergen-and-score))
 
 (defun score (allergen-and-score)
   "Return score from ALLERGEN-AND-SCORE."
-  (second allergen-and-score))
+  (cl-second allergen-and-score))
 
 (defun score-matches (allergen-and-score score)
   "Determine if ALLERGEN-AND-SCORE entry match SCORE."
@@ -30,7 +30,7 @@
 
 (defun find-all (check seq)
   "Find each match for CHECK in SEQ."
-  (remove-if-not check seq))
+  (cl-remove-if-not check seq))
 
 (defun allergen-list (score)
   "List all allergens with a given SCORE."

--- a/exercises/allergies/example.el
+++ b/exercises/allergies/example.el
@@ -34,20 +34,20 @@
 
 (defun allergen-list (score)
   "List all allergens with a given SCORE."
-  (mapcar 'allergen
+  (mapcar #'allergen
           (find-all
-           '(lambda (as) (score-matches as score))
+           (lambda (as) (score-matches as score))
            *allergens-scores*)))
 
 (defun allergic-to-p (score allergen)
   "Allergic-to predicate based on SCORE and ALLERGEN."
-  (score-matches (cl-assoc allergen *allergens-scores* :test 'string=)
+  (score-matches (cl-assoc allergen *allergens-scores* :test #'string=)
                  score))
 
 
 (let ((score 1))
- (find-all
-  '(lambda (as) (score-matches as score)) *allergens-scores*))
+  (find-all
+   (lambda (as) (score-matches as score)) *allergens-scores*))
 
 (provide 'allergies)
 ;;; allergies.el ends here

--- a/exercises/anagram/anagram.el
+++ b/exercises/anagram/anagram.el
@@ -4,7 +4,7 @@
 
 ;;; Code:
 
-(require 'cl)
+(require 'cl-lib)
 
 
 (provide 'anagram)

--- a/exercises/anagram/example.el
+++ b/exercises/anagram/example.el
@@ -8,15 +8,14 @@
 
 (defun anagram-equal (a b)
   "Check that words A and B are anagrams of each other, but not identical."
-  (and
-   (equal (sort (split-string-and-unquote (downcase a) "") 'string<)
-          (sort (split-string-and-unquote (downcase b) "") 'string<))
-   (not (string= a b))))
+  (and (equal (cl-sort (split-string-and-unquote (downcase a) "") #'string<)
+              (cl-sort (split-string-and-unquote (downcase b) "") #'string<))
+       (not (string= a b))))
 
 (defun anagrams-for (subject candidates)
   "Find anagrams for SUBJECT from list of CANDIDATES."
-  (remove-if-not
-   (lambda (w) (anagram-equal w subject)) candidates))
+  (cl-remove-if-not (lambda (w) (anagram-equal w subject))
+                    candidates))
 
 
 (provide 'anagram)

--- a/exercises/anagram/example.el
+++ b/exercises/anagram/example.el
@@ -4,7 +4,7 @@
 
 ;;; Code:
 
-(require 'cl)
+(require 'cl-lib)
 
 (defun anagram-equal (a b)
   "Check that words A and B are anagrams of each other, but not identical."

--- a/exercises/armstrong-numbers/example.el
+++ b/exercises/armstrong-numbers/example.el
@@ -7,7 +7,7 @@
 (defun armstrong-p (n)
   (let* ((digits (mapcar (lambda (d) (- d ?0)) (string-to-list (int-to-string n))))
 	 (p (length digits)))
-    (= n (apply '+ (mapcar (lambda (d) (expt d p)) digits)))))
+    (= n (apply #'+ (mapcar (lambda (d) (expt d p)) digits)))))
 
 (provide 'armstrong-numbers)
 ;;; armstrong-numbers.el ends here

--- a/exercises/atbash-cipher/atbash-cipher-test.el
+++ b/exercises/atbash-cipher/atbash-cipher-test.el
@@ -4,7 +4,7 @@
 
 ;;; Code:
 
-(require 'cl)
+(require 'cl-lib)
 
 (load-file "atbash-cipher.el")
 

--- a/exercises/atbash-cipher/example.el
+++ b/exercises/atbash-cipher/example.el
@@ -14,12 +14,12 @@
 
 (defun to-string (seq)
   "Convert SEQ of characters to a string."
-  (concatenate 'string seq))
+  (cl-concatenate 'string seq))
 
 (defun group (seq &optional group-size)
   "Group SEQ into chunks of size GROUP-SIZE."
   (let ((length (or group-size 5)))
-    (loop
+    (cl-loop
      for c in seq and i from 1
      collect c
      when (and (not (= i (length seq)))
@@ -29,7 +29,7 @@
 
 (defun to-cipher-seq (plaintext)
   "Convert PLAINTEXT to a ciphered sequence."
-  (cleanup-ciphered-seq (map 'list #'encipher plaintext)))
+  (cleanup-ciphered-seq (cl-map 'list #'encipher plaintext)))
 
 (defun cleanup-ciphered-seq (seq)
   "Clean values of char code 0 from SEQ."

--- a/exercises/crypto-square/example.el
+++ b/exercises/crypto-square/example.el
@@ -35,7 +35,7 @@
          (columns (find-rectangle-size text))
          (strings (chop-string text columns))
          (transposed (transpose-strings strings columns)))
-    (mapconcat 'identity transposed " ")))
+    (mapconcat #'identity transposed " ")))
 
 (provide 'crypto-square)
 ;;; crypto-square.el ends here

--- a/exercises/difference-of-squares/example.el
+++ b/exercises/difference-of-squares/example.el
@@ -3,15 +3,15 @@
 ;;; Commentary:
 
 ;;; Code:
-(eval-when-compile (require 'cl-lib))
+(require 'cl-lib)
 
 (defun sum-of-squares (n)
   "Square of sum of N."
-  (reduce #'+ (mapcar (lambda (i) (expt i 2)) (number-sequence 1 n))))
+  (cl-reduce #'+ (mapcar (lambda (i) (expt i 2)) (number-sequence 1 n))))
 
 (defun square-of-sum (n)
   "Sum of squares of N."
-  (expt (reduce #'+ (number-sequence 1 n)) 2))
+  (expt (cl-reduce #'+ (number-sequence 1 n)) 2))
 
 (defun difference (n)
   "Difference of squares pertaining to N."

--- a/exercises/difference-of-squares/example.el
+++ b/exercises/difference-of-squares/example.el
@@ -3,7 +3,7 @@
 ;;; Commentary:
 
 ;;; Code:
-(eval-when-compile (require 'cl))
+(eval-when-compile (require 'cl-lib))
 
 (defun sum-of-squares (n)
   "Square of sum of N."

--- a/exercises/etl/etl-test.el
+++ b/exercises/etl/etl-test.el
@@ -75,7 +75,7 @@
 
 
 (ert-deftest mixed-case-test ()
-  (should (hash-equal (etl mixed-case-input) mixed-case-expected 'string<)))
+  (should (hash-equal (etl mixed-case-input) mixed-case-expected #'string<)))
 
 
 (ert-deftest negative-key-test ()

--- a/exercises/grains/example.el
+++ b/exercises/grains/example.el
@@ -4,7 +4,7 @@
 
 ;;; Code:
 
-(require 'cl)
+(require 'cl-lib)
 
 (defun square (n)
   "Find the number of grains on square N."

--- a/exercises/hamming/example.el
+++ b/exercises/hamming/example.el
@@ -11,14 +11,14 @@
   (if (= (length dna1) (length dna2))
       (let ((dl1 (split-string-and-unquote dna1 ""))
             (dl2 (split-string-and-unquote dna2 "")))
-        (loop with cnt = 0
-              for x in dl1
-              for y in dl2
-              when (not (string= x y))
-              do
-              (setq cnt (1+ cnt))
-              finally
-              return cnt))
+        (cl-loop with cnt = 0
+                 for x in dl1
+                 for y in dl2
+                 when (not (string= x y))
+                 do
+                 (setq cnt (1+ cnt))
+                 finally
+                 return cnt))
     (error "Strands are of different lengths")))
 
 

--- a/exercises/hamming/example.el
+++ b/exercises/hamming/example.el
@@ -4,7 +4,7 @@
 
 ;;; Code:
 
-(require 'cl)
+(require 'cl-lib)
 
 (defun hamming-distance (dna1 dna2)
   "Determine number of mutations between DNA strands DNA1 and DNA2."

--- a/exercises/perfect-numbers/example.el
+++ b/exercises/perfect-numbers/example.el
@@ -4,7 +4,7 @@
 
 ;;; Code:
 
-(require 'cl)
+(require 'cl-lib)
 
 
 (defun divisors (n)

--- a/exercises/perfect-numbers/example.el
+++ b/exercises/perfect-numbers/example.el
@@ -15,7 +15,7 @@
 
 (defun sum-divisors (n)
   ;; Remove n from the list and add'em up.
-  (apply '+ (cdr (sort (divisors n) '>))))
+  (apply #'+ (cdr (sort (divisors n) '>))))
 
 
 (defun perfect-numbers (n)

--- a/exercises/raindrops/example.el
+++ b/exercises/raindrops/example.el
@@ -11,9 +11,9 @@
 (defun convert (n)
   "Convert integer N to its raindrops string."
   (let ((drops "")
-        (factors (remove-if-not (lambda (v)
-                                  (and (>= v 3) (<= v 7)))
-                                (prime-factors n))))
+        (factors (cl-remove-if-not (lambda (v)
+                                     (and (>= v 3) (<= v 7)))
+                                   (prime-factors n))))
     (if (not (null factors))
         (progn
           (when (member 3 factors)

--- a/exercises/raindrops/example.el
+++ b/exercises/raindrops/example.el
@@ -4,7 +4,7 @@
 
 ;;; Code:
 
-(require 'cl)
+(require 'cl-lib)
 
 
 

--- a/exercises/raindrops/raindrops.el
+++ b/exercises/raindrops/raindrops.el
@@ -4,7 +4,7 @@
 
 ;;; Code:
 
-(require 'cl)
+(require 'cl-lib)
 
 
 

--- a/exercises/rna-transcription/example.el
+++ b/exercises/rna-transcription/example.el
@@ -8,10 +8,12 @@
 
 ;;; Code:
 
+(require 'cl-lib)
+
 (defun validate-strand (strand)
   "Check to see if RNA STRAND is valid."
-  (or (every (lambda (c) (find c "ATCGU")) (coerce strand 'list))
-      (signal 'error "Bad strand")))
+  (or (cl-every (lambda (c) (cl-find c "ATCGU")) (cl-coerce strand 'list))
+      (error "Bad strand")))
 
 (defvar dna->rna
   '((?C . ?G) (?G . ?C) (?A . ?U) (?T . ?A)))
@@ -19,9 +21,9 @@
 (defun to-rna (strand)
   "Convert STRAND of DNA to RNA."
   (validate-strand strand)
-  (concatenate 'string
-   (mapcar (lambda (c) (cdr (assoc c dna->rna)))
-           (coerce strand 'list))))
+  (cl-concatenate 'string
+                  (mapcar (lambda (c) (cdr (assoc c dna->rna)))
+                          (cl-coerce strand 'list))))
 
 
 (provide 'rna-transcription)

--- a/exercises/rna-transcription/rna-transcription-test.el
+++ b/exercises/rna-transcription/rna-transcription-test.el
@@ -5,7 +5,7 @@
 
 ;;; Code:
 
-(require 'cl)
+(require 'cl-lib)
 
 (load-file "rna-transcription.el")
 

--- a/exercises/roman-numerals/example.el
+++ b/exercises/roman-numerals/example.el
@@ -29,7 +29,7 @@
           (setq roman (append roman (make-list (/ value d) r)))
           (setq value (% value d)))
         (setq decode (cdr decode))))
-    (apply 'concat roman)))
+    (apply #'concat roman)))
 
 
 (provide 'roman-numerals)


### PR DESCRIPTION
Set a good example!  Feature 'cl has been deprecated for some time.

https://emacs.stackexchange.com/a/48115/2264