### PR TITLE
Let word-count tests run multiple times correctly

### DIFF
--- a/exercises/word-count/word-count-test.el
+++ b/exercises/word-count/word-count-test.el
@@ -8,8 +8,9 @@
 
 
 (defun equal-assoc (a b)
-  (equal (sort a (lambda (a b) (not (string< (car a) (car b)))))
-         (sort b (lambda (a b) (not (string< (car a) (car b)))))))
+  (let ((strcmp (lambda (a b) (not (string< (car a) (car b))))))
+    (equal (sort (copy-sequence a) strcmp)
+           (sort (copy-sequence b) strcmp))))
 
 
 (ert-deftest no-words-test ()


### PR DESCRIPTION
`sort` is a destructive function, so it should not be passed quoted
values like those used in the tests.  Otherwise, the second time the
tests are run, they will compare against corrupted values.