### PR TITLE
Adjust core track to help ease bottlenecks

### DIFF
--- a/config.json
+++ b/config.json
@@ -84,8 +84,8 @@
       "unlocked_by": null,
       "difficulty": 1,
       "topics": [
-        "strings",
-        "control_flow_loops"
+        "control_flow_loops",
+        "strings"
       ]
     },
     {
@@ -320,9 +320,9 @@
       "unlocked_by": null,
       "difficulty": 2,
       "topics": [
+        "cryptograpy",
         "strings",
-        "transforming",
-        "cryptograpy"
+        "transforming"
       ]
     },
     {
@@ -332,9 +332,9 @@
       "unlocked_by": null,
       "difficulty": 3,
       "topics": [
-        "strings",
-        "list operations",
-        "checksums"
+        "checksums",
+        "list_operations",
+        "strings"
       ]
     }
   ]

--- a/config.json
+++ b/config.json
@@ -25,15 +25,42 @@
       ]
     },
     {
-      "slug": "bob",
-      "uuid": "c02c7392-9478-4cfd-81eb-0cb8ebe78fe5",
+      "slug": "leap",
+      "uuid": "84eaff19-cb25-46af-a34e-1379e692e57b",
       "core": true,
       "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "control_flow_conditionals",
-        "parsing",
+        "equality",
+        "integers",
+        "logic"
+      ]
+    },
+    {
+      "slug": "anagram",
+      "uuid": "d8906a7e-9d7e-4e8e-aff0-da877291d8dc",
+      "core": true,
+      "unlocked_by": null,
+      "difficulty": 2,
+      "topics": [
+        "equality",
+        "filtering",
         "strings"
+      ]
+    },
+    {
+      "slug": "roman-numerals",
+      "uuid": "c4875bc5-e295-4782-99c7-cb3370ac8e08",
+      "core": true,
+      "unlocked_by": null,
+      "difficulty": 1,
+      "topics": [
+        "control_flow_conditionals",
+        "control_flow_loops",
+        "integers",
+        "strings",
+        "text_formatting"
       ]
     },
     {
@@ -51,31 +78,6 @@
       ]
     },
     {
-      "slug": "anagram",
-      "uuid": "d8906a7e-9d7e-4e8e-aff0-da877291d8dc",
-      "core": true,
-      "unlocked_by": null,
-      "difficulty": 2,
-      "topics": [
-        "equality",
-        "filtering",
-        "strings"
-      ]
-    },
-    {
-      "slug": "leap",
-      "uuid": "84eaff19-cb25-46af-a34e-1379e692e57b",
-      "core": true,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": [
-        "control_flow_conditionals",
-        "equality",
-        "integers",
-        "logic"
-      ]
-    },
-    {
       "slug": "rna-transcription",
       "uuid": "7b6767b9-2efc-414d-83f7-def9c371d63d",
       "core": true,
@@ -88,17 +90,15 @@
       ]
     },
     {
-      "slug": "roman-numerals",
-      "uuid": "c4875bc5-e295-4782-99c7-cb3370ac8e08",
+      "slug": "bob",
+      "uuid": "c02c7392-9478-4cfd-81eb-0cb8ebe78fe5",
       "core": true,
       "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "control_flow_conditionals",
-        "control_flow_loops",
-        "integers",
-        "strings",
-        "text_formatting"
+        "parsing",
+        "strings"
       ]
     },
     {

--- a/config.json
+++ b/config.json
@@ -37,6 +37,84 @@
       ]
     },
     {
+      "slug": "hamming",
+      "uuid": "2bfb508e-7ceb-4ae1-8316-1e2daf771807",
+      "core": true,
+      "unlocked_by": null,
+      "difficulty": 1,
+      "topics": [
+        "control_flow_conditionals",
+        "control_flow_loops",
+        "equality",
+        "filtering",
+        "strings"
+      ]
+    },
+    {
+      "slug": "anagram",
+      "uuid": "d8906a7e-9d7e-4e8e-aff0-da877291d8dc",
+      "core": true,
+      "unlocked_by": null,
+      "difficulty": 2,
+      "topics": [
+        "equality",
+        "filtering",
+        "strings"
+      ]
+    },
+    {
+      "slug": "leap",
+      "uuid": "84eaff19-cb25-46af-a34e-1379e692e57b",
+      "core": true,
+      "unlocked_by": null,
+      "difficulty": 1,
+      "topics": [
+        "control_flow_conditionals",
+        "equality",
+        "integers",
+        "logic"
+      ]
+    },
+    {
+      "slug": "rna-transcription",
+      "uuid": "7b6767b9-2efc-414d-83f7-def9c371d63d",
+      "core": true,
+      "unlocked_by": null,
+      "difficulty": 1,
+      "topics": [
+        "control_flow_conditionals",
+        "strings",
+        "transforming"
+      ]
+    },
+    {
+      "slug": "roman-numerals",
+      "uuid": "c4875bc5-e295-4782-99c7-cb3370ac8e08",
+      "core": true,
+      "unlocked_by": null,
+      "difficulty": 1,
+      "topics": [
+        "control_flow_conditionals",
+        "control_flow_loops",
+        "integers",
+        "strings",
+        "text_formatting"
+      ]
+    },
+    {
+      "slug": "word-count",
+      "uuid": "1a3c64b1-8447-451f-985d-f7bd6d42bdb6",
+      "core": true,
+      "unlocked_by": null,
+      "difficulty": 2,
+      "topics": [
+        "control_flow_conditionals",
+        "control_flow_loops",
+        "filtering",
+        "strings"
+      ]
+    },
+    {
       "slug": "difference-of-squares",
       "uuid": "7b421b14-c33c-41a6-9e7e-4f9b6fbe6fcc",
       "core": false,
@@ -64,20 +142,6 @@
       ]
     },
     {
-      "slug": "hamming",
-      "uuid": "2bfb508e-7ceb-4ae1-8316-1e2daf771807",
-      "core": true,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": [
-        "control_flow_conditionals",
-        "control_flow_loops",
-        "equality",
-        "filtering",
-        "strings"
-      ]
-    },
-    {
       "slug": "pangram",
       "uuid": "28aea3bc-0ca0-4af9-868a-02e71c3d996",
       "core": false,
@@ -85,18 +149,6 @@
       "difficulty": 1,
       "topics": [
         "control_flow_loops",
-        "strings"
-      ]
-    },
-    {
-      "slug": "anagram",
-      "uuid": "d8906a7e-9d7e-4e8e-aff0-da877291d8dc",
-      "core": true,
-      "unlocked_by": null,
-      "difficulty": 2,
-      "topics": [
-        "equality",
-        "filtering",
         "strings"
       ]
     },
@@ -111,19 +163,6 @@
         "control_flow_conditionals",
         "integers",
         "math"
-      ]
-    },
-    {
-      "slug": "leap",
-      "uuid": "84eaff19-cb25-46af-a34e-1379e692e57b",
-      "core": true,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": [
-        "control_flow_conditionals",
-        "equality",
-        "integers",
-        "logic"
       ]
     },
     {
@@ -152,18 +191,6 @@
       ]
     },
     {
-      "slug": "rna-transcription",
-      "uuid": "7b6767b9-2efc-414d-83f7-def9c371d63d",
-      "core": true,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": [
-        "control_flow_conditionals",
-        "strings",
-        "transforming"
-      ]
-    },
-    {
       "slug": "atbash-cipher",
       "uuid": "89125ff6-f94b-46a4-9a5d-84539674238d",
       "core": false,
@@ -189,20 +216,6 @@
       ]
     },
     {
-      "slug": "roman-numerals",
-      "uuid": "c4875bc5-e295-4782-99c7-cb3370ac8e08",
-      "core": true,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": [
-        "control_flow_conditionals",
-        "control_flow_loops",
-        "integers",
-        "strings",
-        "text_formatting"
-      ]
-    },
-    {
       "slug": "perfect-numbers",
       "uuid": "30971b02-79fc-40a1-aa70-ada3fec85548",
       "core": false,
@@ -223,19 +236,6 @@
         "control_flow_loops",
         "maps",
         "transforming"
-      ]
-    },
-    {
-      "slug": "word-count",
-      "uuid": "1a3c64b1-8447-451f-985d-f7bd6d42bdb6",
-      "core": true,
-      "unlocked_by": null,
-      "difficulty": 2,
-      "topics": [
-        "control_flow_conditionals",
-        "control_flow_loops",
-        "filtering",
-        "strings"
       ]
     },
     {


### PR DESCRIPTION
**TL;DR:**
This PR reorders the core exercises; see the end for the new ordering.
Please read the full thing before replying!

---

I wrote a script that takes some data points into account to reorder the core track's exercises.

This is not meant to be the "be all end all" of perfection :-)
This is an attempt to make some simple changes in the short term. In the longer term, over the next 12 months, the product team will be doing a bunch of work to dig into what makes great Exercism exercises, and how to structure tracks to provide a better experience for both learners and mentors.

**Once this goes live** we will continue to monitor the continuation rate, the median wait time, and a few other stats as well, to help decide whether or not we need to take any other immediate steps. That said, if you see anything weird or worrying once the change is out, please ping us on Slack (or here) so we can discuss a fix posthaste!

**The most helpful thing you can do in reviewing this** is to look at the resulting core track and tell me whether anything is obviously terrible or suspiciously weird. I know very little about the Elisp track (or the language, for that matter), so I could easily have missed something.

I'd also appreciate it if you posted this to the mentors as a heads up, and also because mentors tend to have a great gut sense about the core exercises.

## Bottleneck detection and fixes

The data that I based the reordering on was taken from the production database, and is based on the last 6 months.

I reordered by taking the original order, and then giving "penalty points" for two different things

- low continuation rates (percentage)
- long wait times in the mentor queue (median wait time in minutes)

"Continuation" is when someone completes an exercise, but then does not submit the following exercise. We have other interesting numbers that we may use to adjust things in the future, but this one seemed like our best bet for now for the bottlenecks. I somewhat arbitrarily chose 80% as the cutoff for whether or not to give penalty points, i.e. continuation rate < 80% gets penalized. The only exercise I did not penalize based on this rate was the exercise directly following `hello-world`, since `hello-world` is basically just a taste test, and it is natural to assume that many people will decide that Exercism is not really for them. But even then... Elisp has a _fantastic_ continuation rate past hello world. Seriously. I've seen tracks that are more like 30%.

<details>
 <summary>Continuation rates</summary>

```
- hello-world (100%)
- two-fer (86%)
- bob (60%)
- hamming (80%)
- anagram (86%)
- leap (95%)
- rna-transcription (82%)
- roman-numerals (92%)
- word-count (89%)
```

</details>

Long wait times in the mentor queue is an indication that mentors don't enjoy mentoring the exercise, or put it off. This could be for a number of reasons, which we have not explicitly identified, but we've observed that sometimes the exercise is simply too difficult in the current position, which means that mentors have to go back and forth a whole bunch with students to get something right, and the discussions can be quite frustrating. Also sometimes the exercise is just not very interesting to mentor. Or if the exercise is too early in the track sometimes people will submit lots of really complicated solutions rather than a small handful of mostly reasonable solutions, also making it harder to mentor.

So this pushes exercises with long wait times further back in the core track. We may decide that we need to remove some exercises from core altogether, if wait times continue to be bad.

<details>
 <summary>Wait times</summary>

```
- hello-world (0 min)
- two-fer (8827 min)
- bob (5788 min)
- hamming (8533 min)
- anagram (2469 min)
- leap (109 min)
- rna-transcription (6970 min)
- roman-numerals (4356 min)
- word-count (10082 min)
```
</details>

### Outcome

#### Before
```
- hello-world
- two-fer
- bob
- hamming
- anagram
- leap
- rna-transcription
- roman-numerals
- word-count
```

#### After

_Note: the numbers indicate the position in the core track, as defined by the index of the array. Minus means that it moved earlier, plus means that it moved later._
```
- hello-world
- two-fer
- leap (-3)
- anagram (-1)
- roman-numerals (-3)
- hamming (+2)
- rna-transcription
- bob (+5)
- word-count
```
