### PR TITLE
Stub check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,5 @@ before_install:
 script:
   - bin/fetch-configlet
   - bin/configlet lint .
+  - bin/stub-check
   - bin/test-examples

--- a/bin/stub-check
+++ b/bin/stub-check
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+# convenience to pretend like this is perl
+die () {
+    # the unicode value prints '✗'
+    printf '\u2717 %s\n' "${1:-'something has gone horribly wrong'}"
+    exit 1
+}
+
+success () {
+    # the unicode value prints '✓'
+    printf '\u2713 %s\n' "$1"
+}
+
+# make sure we are in the right place
+#
+# special '##' syntax removes the prefix from $PWD
+if [[ elisp == ${PWD##*/} ]]; then
+    # make life easier = less string parsing
+    cd exercises
+else
+    # can't run this script from wherever we are
+    die "can't run 'stub-check' from ${PWD}."
+fi
+
+# loop the directory in 'elisp/exercises'
+for exercise in *; do
+    # verify the existence of the stub file
+    if [[ -f "${exercise}/${exercise}.el" ]]; then
+        success "$exercise"
+    else
+        # no stub present
+        die "${exercise} is is missing its stub file."
+    fi
+done

--- a/bin/stub-check
+++ b/bin/stub-check
@@ -1,15 +1,20 @@
 #!/usr/bin/env bash
 
-# convenience to pretend like this is perl
-die () {
-    # the unicode value prints '✗'
-    printf '\u2717 %s\n' "${1:-'something has gone horribly wrong'}"
-    exit 1
+# handle colors and the unicode symbols '✓' and '✗'
+readonly NORMAL="$(tput sgr0)"
+readonly RED_FAIL="$(tput setaf 1)$(printf '\u2717')"
+readonly GREEN_PASS="$(tput setaf 2)$(printf '\u2713')"
+
+# format the success messages
+success () {
+    printf '%s\n' "${GREEN_PASS}${NORMAL} ${1}"
 }
 
-success () {
-    # the unicode value prints '✓'
-    printf '\u2713 %s\n' "$1"
+# convenience to pretend like this is perl
+die () {
+    local err="${1:-something has gone horribly wrong}"
+    printf '%s\n' "${RED_FAIL}${NORMAL} ${err}"
+    exit 1
 }
 
 # make sure we are in the right place


### PR DESCRIPTION
fixes #124

---
I wrote a bash script to verify that all exercises have a stub present in their directory.

I can include tests to verify it's behavior too if that is desired.

---
#### Although, an easy way to test it manually is:
1. Run the script from a directory other than `elisp`, ie. the repo root.
2. Make an empty directory in `elisp/exercises` and then run the script to watch it catch the problem.

---
Also you can see how the output looks in the travis logs