### PR TITLE
change leap to leap-year-p

### DIFF
--- a/exercises/leap/leap.el
+++ b/exercises/leap/leap.el
@@ -5,5 +5,5 @@
 ;;; Code:
 
 
-(provide 'leap)
+(provide 'leap-year-p)
 ;;; leap.el ends here


### PR DESCRIPTION
According to tests the expected function should be named `leap-year-p`.